### PR TITLE
Use ':trusty' tag to track latest Trusty point release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:trusty
 MAINTAINER Johannes 'fish' Ziemke <docker@freigeist.org>
 
 RUN \


### PR DESCRIPTION
Currently latest Trusty is 14.04.1
